### PR TITLE
fix: ignore pages that have not been loaded yet

### DIFF
--- a/background.js
+++ b/background.js
@@ -1499,6 +1499,11 @@ function handleMessage(message, sender, sendResponse) {
 		return;
 	}
 
+	if (sender.documentLifecycle === "prerender") {
+		// ignore pages that have not been loaded yet
+		return;
+	}
+
 	//log("handleMessage: " + sender.tab.id + " " + message.type);
 
 	switch (message.type) {


### PR DESCRIPTION
There's a bug that will cause LeechBlock to activate even on domains that are not blocked. It has to do with Chrome's speculative prerendering.

For example, if you are on not-blocked.example and start typing "blocked.example" in the omnibox, Chrome will start preloading it in the current tab, which will cause LeechBlock to activate, even though no navigation has taken place yet.